### PR TITLE
Fix SDK import path

### DIFF
--- a/main.py
+++ b/main.py
@@ -2,6 +2,8 @@ import logging
 import random
 import time
 from threading import Lock
+import os, sys
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "hyperliquid-python-sdk"))
 
 from eth_account import Account
 


### PR DESCRIPTION
## Summary
- fix import path for the hyperliquid Python SDK

## Testing
- `git status --short`