### PR TITLE
Restrict bot to UBTC market

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,8 +5,7 @@ Hyperliquid exchange using the bundled Python SDK.
 
 ## Checking available markets
 
-Before running the bot you may want to know which trading pairs are supported.
-The SDK exposes this via `Info.name_to_coin`:
+The SDK exposes available markets via `Info.name_to_coin`:
 
 ```python
 from hyperliquid.info import Info
@@ -14,21 +13,16 @@ info = Info("https://api.hyperliquid.xyz")
 print(info.name_to_coin.keys())
 ```
 
-Running the snippet above will print a dictionary view of all valid market
-names. Any of those names can be used when starting the bot.
+The bot itself is locked to the `UBTC/USDC` pair, but you may find the snippet
+above useful for reference.
 
 ## Usage
 
-The bot is started by running `main.py`. By default it operates on the
-`BTC/USDC` market. You can override this either via a command line argument or
-by setting the `MARKET` environment variable.
+The bot is started by running `main.py` and exclusively trades the
+`UBTC/USDC` spot pair.
 
 ```bash
-# Using an environment variable
-MARKET="ETH/USDC" python main.py
-
-# Or using the command line argument
-python main.py --market ETH/USDC
+python main.py
 ```
 
 Make sure you have configured the credentials in `config.py` before starting the

--- a/main.py
+++ b/main.py
@@ -19,7 +19,7 @@ class SpotLiquidityBot:
 
     def __init__(
         self,
-        market: str = "BTC/USDC",
+        market: str = "UBTC/USDC",
         size_min: float = 5,
         size_max: float = 10,
         spread: float = 0.0002,
@@ -30,6 +30,8 @@ class SpotLiquidityBot:
         dynamic_reprice_on_bbo: bool = False,
     ) -> None:
         self.market = market
+        if self.market != "UBTC/USDC":
+            raise ValueError("SpotLiquidityBot only supports the UBTC/USDC market")
         self.size_min = size_min
         self.size_max = size_max
         self.spread = spread
@@ -258,18 +260,5 @@ class SpotLiquidityBot:
 
 
 if __name__ == "__main__":
-    import argparse
-
-    # Allow overriding the default market via environment variable or CLI.
-    default_market = os.getenv("MARKET", "BTC/USDC")
-
-    parser = argparse.ArgumentParser(description="Run the spot liquidity bot")
-    parser.add_argument(
-        "--market",
-        help="Trading pair to market make, e.g. BTC/USDC. Overrides $MARKET.",
-    )
-    args = parser.parse_args()
-
-    market = args.market or default_market
-    bot = SpotLiquidityBot(market=market)
+    bot = SpotLiquidityBot()
     bot.run()


### PR DESCRIPTION
## Summary
- limit `SpotLiquidityBot` to UBTC/USDC
- simplify `main.py` entry point to use the default market
- update README to explain bot only trades UBTC/USDC

## Testing
- `python3 -m py_compile main.py config.py`
