### PR TITLE
Fix environment proxy issues

### DIFF
--- a/README.md
+++ b/README.md
@@ -21,6 +21,13 @@ export BASE_URL=https://api.hyperliquid.xyz      # default value
 export RPC_URL=https://api.hyperliquid.xyz/rpc   # default value
 ```
 
+If your environment sets `http_proxy` or `https_proxy`, unset them before
+running the bot so requests go directly to the Hyperliquid API:
+
+```bash
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+```
+
 3. Start the bot using the provided script which sets up a virtual
    environment and runs `main.py`:
 

--- a/run.sh
+++ b/run.sh
@@ -7,11 +7,18 @@ PYTHON_VERSION="python3.12"
 VENV_DIR=".venv"
 LOG_DIR="logs"
 
+# Proxy-Umgebungsvariablen deaktivieren, damit Requests direkt an die
+# Hyperliquid-API gesendet werden können.
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
+
 # === Virtuelle Umgebung erstellen (falls nicht vorhanden) ===
-if [ ! -d "$VENV_DIR" ]; then
+if [ ! -x "$VENV_DIR/bin/python" ]; then
   echo "[INFO] Erstelle virtuelle Umgebung mit $PYTHON_VERSION..."
-  $PYTHON_VERSION -m venv $VENV_DIR
+  rm -rf "$VENV_DIR"
+  $PYTHON_VERSION -m venv "$VENV_DIR"
   echo "[INFO] Virtuelle Umgebung erstellt."
+  "$VENV_DIR/bin/pip" install --upgrade pip >/dev/null
+  "$VENV_DIR/bin/pip" install -e hyperliquid-python-sdk >/dev/null
 fi
 
 # === Logs-Ordner erstellen (falls nicht vorhanden) ===


### PR DESCRIPTION
## Summary
- disable proxy variables before starting bot so API requests hit Hyperliquid
- recreate virtualenv if interpreter missing and install SDK
- document proxy removal in README

## Testing
- `./run.sh` *(fails: ModuleNotFoundError: No module named 'eth_account')*