### PR TITLE
Improve repricing workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,3 +95,13 @@ bot = SpotLiquidityBot(start_order_price=90000, start_order_size=0.001)
 The bot normally starts **without** a test order; the example above would submit
 a buy for `0.001` BTC at `90,000` USDC right after launch.
 
+## Repricing behaviour
+
+Orders are periodically repriced when the mid price drifts too far from the
+original order price. The `reprice_threshold` parameter now defaults to
+`2 * spread`, automatically scaling with your chosen spread.
+
+When `dynamic_reprice_on_bbo` is enabled, cancelled orders are replaced
+immediately after a best bid/offer update instead of waiting for the normal
+`check_interval` loop.
+

--- a/main.py
+++ b/main.py
@@ -30,7 +30,7 @@ class SpotLiquidityBot:
         check_interval: int = 5,
         log_file: str = "trade_log.txt",
         volume_log_file: str = "volume_log.txt",
-        reprice_threshold: float = 0.005,
+        reprice_threshold: float | None = None,
         dynamic_reprice_on_bbo: bool = False,
         *,
         usd_size_min: float | None = None,
@@ -47,7 +47,9 @@ class SpotLiquidityBot:
         self.usd_size_max = usd_size_max
         self.spread = spread
         self.check_interval = check_interval
-        self.reprice_threshold = reprice_threshold
+        self.reprice_threshold = (
+            reprice_threshold if reprice_threshold is not None else 2 * spread
+        )
         self.dynamic_reprice_on_bbo = dynamic_reprice_on_bbo
         self.start_order_price = start_order_price
         self.start_order_size = start_order_size
@@ -266,6 +268,7 @@ class SpotLiquidityBot:
         mid = self._mid_price()
         if mid is None:
             return
+        cancelled = False
         for oid, info in list(self.open_orders.items()):
             level = info.get("level", 1)
             target_price = self._price_for_side(info["side"], level, mid)
@@ -275,6 +278,9 @@ class SpotLiquidityBot:
                 )
                 self.cancel_order(oid)
                 self.open_orders.pop(oid, None)
+                cancelled = True
+        if cancelled:
+            self.ensure_orders()
 
     def run(self) -> None:
         self._log("Bot started")


### PR DESCRIPTION
## Summary
- base `reprice_threshold` on the chosen spread
- immediately replace orders when dynamic repricing cancels them
- document repricing behaviour

## Testing
- `python3 -m py_compile main.py config.py`