### PR TITLE
Insert proxy unset

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -9,6 +9,7 @@ LOG_DIR="logs"
 
 # === 🔐 Wallet-Zugangsdaten ===
 export WALLET_PRIVATE_KEY="0x9766a78dfde13e3427b74ae751d1386b4c7319bc6bfef6e9bc21a31f6e4bfb3c"
+unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
 export WALLET_ADDRESS="0x2604a13f7e643b8f5b3c894d6023d6de8c4e1682"
 
 # === ⚙️ Virtuelle Umgebung erstellen (falls nicht vorhanden) ===


### PR DESCRIPTION
## Summary
- disable proxy environment variables for run.sh

## Testing
- `./run.sh` *(fails: .venv/bin/python not found)*