### PR TITLE
Adjust minimum USD order size

### DIFF
--- a/README.md
+++ b/README.md
@@ -69,13 +69,13 @@ bot.
 
 Orders can be sized in UBTC via the `size_min` and `size_max`
 parameters.  Every order must also satisfy a USD value range.
-`min_usd_order_size` enforces the exchange's minimum (default: `10`),
+`min_usd_order_size` enforces the exchange's minimum (default: `20`),
 while `max_usd_order_size` (default: `50`) prevents overly large orders
 when the BTC price changes.
 
 ```python
 bot = SpotLiquidityBot(size_min=0.0002, size_max=0.0003,
-                       min_usd_order_size=10,
+                       min_usd_order_size=20,
                        max_usd_order_size=50)
 ```
 

--- a/main.py
+++ b/main.py
@@ -39,7 +39,7 @@ class SpotLiquidityBot:
         # Falls es 0.5 oder 0.1 sein soll, bitte anpassen.
         price_tick: float = 1.0,
         max_usd_order_size: float = 50.0,
-        min_usd_order_size: float = 10.0,
+        min_usd_order_size: float = 20.0,
     ) -> None:
         """Create a new bot instance.
 
@@ -362,6 +362,6 @@ if __name__ == "__main__":
         price_tick=1.0,
         debug=True,
         max_usd_order_size=50.0,
-        min_usd_order_size=10.0,
+        min_usd_order_size=20.0,
     )
     bot.run()


### PR DESCRIPTION
## Summary
- raise `min_usd_order_size` default to 20 USD
- update example usage and README docs

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*