### PR TITLE
Add 0.0004 spread param and docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -75,9 +75,14 @@ when the BTC price changes.
 
 ```python
 bot = SpotLiquidityBot(size_min=0.0002, size_max=0.0003,
+                       spread=0.0004,
                        min_usd_order_size=20,
                        max_usd_order_size=50)
 ```
+
+`spread=0.0004` means orders are quoted 0.04% away from the mid price
+on each side. This small buffer keeps them from filling immediately
+while still providing tight liquidity.
 
 No single order will exceed the configured USD limit.  Adjust the
 values to suit the size of your account.

--- a/main.py
+++ b/main.py
@@ -359,6 +359,7 @@ if __name__ == "__main__":
         # Test: Tick-Size = 1 USDC, min Size = 0.001 UBTC
         size_min=0.00005,
         size_max=0.0001,
+        spread=0.0004,
         price_tick=1.0,
         debug=True,
         max_usd_order_size=50.0,


### PR DESCRIPTION
## Summary
- add `spread=0.0004` to the default bot instantiation in `main.py`
- explain the choice of `0.0004` spread in README example

## Testing
- `python -m py_compile main.py`