### PR TITLE
Improve order cleanup and tracking

### DIFF
--- a/README.md
+++ b/README.md
@@ -104,6 +104,8 @@ a buy for `0.001` BTC at `90,000` USDC right after launch.
 On every startup the bot also cleans up any open orders that may still
 be resting on the exchange. This ensures stale orders don't consume
 capital before new quotes are placed.
+After the cleanup the bot refreshes its internal state with any orders
+that remain so the expiration timer works even across restarts.
 
 ## Repricing behaviour
 


### PR DESCRIPTION
## Summary
- cancel all open orders in bulk on startup
- refresh internal order list with `load_open_orders`
- document the startup cleanup step

## Testing
- `python3 -m py_compile main.py`
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*