### PR TITLE
Fix environment-based wallet config

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,6 +14,9 @@ export WALLET_PRIVATE_KEY=<your_private_key>
 export WALLET_ADDRESS=<your_wallet_address>
 ```
 
+`run.sh` prüft diese Variablen beim Start und bricht mit einer Fehlermeldung
+ab, falls sie fehlen.
+
 Optional environment variables:
 
 ```bash

--- a/run.sh
+++ b/run.sh
@@ -8,9 +8,15 @@ VENV_DIR=".venv"
 LOG_DIR="logs"
 
 # === 🔐 Wallet-Zugangsdaten ===
-export WALLET_PRIVATE_KEY="0x9766a78dfde13e3427b74ae751d1386b4c7319bc6bfef6e9bc21a31f6e4bfb3c"
+# Die notwendigen Umgebungsvariablen müssen bereits gesetzt sein.
+if [ -z "$WALLET_PRIVATE_KEY" ] || [ -z "$WALLET_ADDRESS" ]; then
+  echo "[ERROR] WALLET_PRIVATE_KEY und WALLET_ADDRESS müssen gesetzt sein." >&2
+  echo "Beispiel:" >&2
+  echo "  export WALLET_PRIVATE_KEY=0x..." >&2
+  echo "  export WALLET_ADDRESS=0x..." >&2
+  exit 1
+fi
 unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
-export WALLET_ADDRESS="0x2604a13f7e643b8f5b3c894d6023d6de8c4e1682"
 
 # === ⚙️ Virtuelle Umgebung erstellen (falls nicht vorhanden) ===
 if [ ! -d "$VENV_DIR" ]; then


### PR DESCRIPTION
## Summary
- ensure run.sh uses user's wallet credentials instead of hard-coded examples
- mention wallet environment variables in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*