### PR TITLE
Normalize coin argument in market_close

### DIFF
--- a/hyperliquid-python-sdk/hyperliquid/exchange.py
+++ b/hyperliquid-python-sdk/hyperliquid/exchange.py
@@ -235,6 +235,7 @@ class Exchange(API):
         cloid: Optional[Cloid] = None,
         builder: Optional[BuilderInfo] = None,
     ) -> Any:
+        coin = self.info.name_to_coin.get(coin, coin)
         address: str = self.wallet.address
         if self.account_address:
             address = self.account_address


### PR DESCRIPTION
## Summary
- map `coin` arg to canonical form in `market_close`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*