### PR TITLE
Shorten order expiration

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,7 +81,7 @@ bot = SpotLiquidityBot(size_min=0.0002, size_max=0.0003,
                        spread=0.0004,
                        min_usd_order_size=20,
                        max_usd_order_size=50,
-                       max_order_age=300)
+                       max_order_age=60)
 ```
 
 `spread=0.0004` means orders are quoted 0.04% away from the mid price
@@ -125,6 +125,6 @@ immediately after a best bid/offer update instead of waiting for the normal
 ## Order expiration
 
 Each order is tagged with a timestamp when placed.  If an order remains open
-longer than `max_order_age` seconds (default: `300`), it will be cancelled on
+longer than `max_order_age` seconds (default: `60`), it will be cancelled on
 the next iteration of the main loop.
 

--- a/main.py
+++ b/main.py
@@ -40,7 +40,7 @@ class SpotLiquidityBot:
         price_tick: float = 1.0,
         max_usd_order_size: float = 50.0,
         min_usd_order_size: float = 20.0,
-        max_order_age: int = 300,
+        max_order_age: int = 60,
     ) -> None:
         """Create a new bot instance.
 
@@ -473,6 +473,6 @@ if __name__ == "__main__":
         debug=True,
         max_usd_order_size=50.0,
         min_usd_order_size=20.0,
-        max_order_age=300,
+        max_order_age=60,
     )
     bot.run()


### PR DESCRIPTION
## Summary
- orders expire after 60 seconds rather than 5 minutes
- document new default in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*