### PR TITLE
Add requirements and test instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,3 +128,17 @@ Each order is tagged with a timestamp when placed.  If an order remains open
 longer than `max_order_age` seconds (default: `60`), it will be cancelled on
 the next iteration of the main loop.
 
+
+## Running tests
+
+Install the Python dependencies using `requirements.txt`:
+
+```bash
+pip install -r requirements.txt
+```
+
+Then execute the test suite:
+
+```bash
+pytest
+```

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,16 @@
+# Core dependencies
+requests==2.31.0
+msgpack==1.0.5
+websocket-client==1.5.1
+eth-utils>=2.1.0,<6.0.0
+eth-account>=0.10.0,<0.14.0
+
+# Test dependencies
+pytest==8.3.4
+pytest-recording==0.13.2
+coverage==7.6.10
+pytest-cov==6.0.0
+vcrpy==7.0.0
+types-requests==2.31.0
+lz4==4.3
+


### PR DESCRIPTION
## Summary
- list package dependencies in `requirements.txt`
- explain how to install them before running `pytest`

## Testing
- `pytest hyperliquid-python-sdk/tests` *(fails: unrecognized arguments)*