### PR TITLE
Update README startup notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,13 @@ This repository contains a simple trading bot built on top of the
 ## Setup
 
 1. Ensure Python 3.12 is available.
-2. Export your wallet credentials before running the bot:
+2. Install dependencies from the bundled SDK:
+
+```bash
+pip install -e hyperliquid-python-sdk
+```
+
+3. Export your wallet credentials before running the bot:
 
 ```bash
 export WALLET_PRIVATE_KEY=<your_private_key>
@@ -31,7 +37,7 @@ running the bot so requests go directly to the Hyperliquid API:
 unset http_proxy https_proxy HTTP_PROXY HTTPS_PROXY
 ```
 
-3. Start the bot using the provided script which sets up a virtual
+4. Start the bot using the provided script which sets up a virtual
    environment and runs `main.py`:
 
 ```bash
@@ -106,9 +112,9 @@ a buy for `0.001` BTC at `90,000` USDC right after launch.
 
 On every startup the bot also cleans up any open orders that may still
 be resting on the exchange. This ensures stale orders don't consume
-capital before new quotes are placed.  The cleanup now uses the SDK's
-`schedule_cancel(None)` method so **all** markets are cleared, mirroring
-the "Cancel All" button in the Hyperliquid UI.  After the cleanup the bot
+capital before new quotes are placed. The `cancel_all_open_orders` helper now
+sends a single `bulk_cancel` request so **all** markets are cleared, mirroring
+the "Cancel All" button in the Hyperliquid UI. After the cleanup the bot
 refreshes its internal state with any orders that remain so the
 expiration timer works even across restarts.
 


### PR DESCRIPTION
## Summary
- document pip install step for hyperliquid sdk
- clarify startup cleanup uses `bulk_cancel` via `cancel_all_open_orders`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*