### PR TITLE
Update BASE_URL instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,6 +30,24 @@ export BASE_URL=https://api.hyperliquid.xyz      # default value
 export RPC_URL=https://api.hyperliquid.xyz/rpc   # default value
 ```
 
+`BASE_URL` should only contain the root API domain. **Do not** append `/rpc` or
+any other suffix—using the wrong URL leads to `404` errors when fetching
+`openOrders`.
+
+Example values for mainnet:
+
+```bash
+export BASE_URL=https://api.hyperliquid.xyz
+export RPC_URL=https://api.hyperliquid.xyz/rpc
+```
+
+And for testnet:
+
+```bash
+# export BASE_URL=https://api.hyperliquid-testnet.xyz
+# export RPC_URL=https://api.hyperliquid-testnet.xyz/rpc
+```
+
 If your environment sets `http_proxy` or `https_proxy`, unset them before
 running the bot so requests go directly to the Hyperliquid API:
 


### PR DESCRIPTION
## Summary
- clarify BASE_URL usage in README
- add examples for mainnet and testnet

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*
- `pip install -r requirements.txt` *(fails: Could not find a version that satisfies the requirement requests==2.31.0)*