### PR TITLE
Add requirements-dev and update tests docs

### DIFF
--- a/README.md
+++ b/README.md
@@ -137,10 +137,11 @@ the next iteration of the main loop.
 
 ## Running tests
 
-Install the Python dependencies using `requirements.txt`:
+Install the Python dependencies using `requirements.txt` and the additional
+packages required for tests listed in `requirements-dev.txt`:
 
 ```bash
-pip install -r requirements.txt
+pip install -r requirements.txt -r requirements-dev.txt
 ```
 
 Then execute the test suite:

--- a/requirements-dev.txt
+++ b/requirements-dev.txt
@@ -1,0 +1,10 @@
+# Development and test dependencies
+requests==2.31.0
+pytest==8.3.4
+eth-account>=0.10.0,<0.14.0
+pytest-recording==0.13.2
+coverage==7.6.10
+pytest-cov==6.0.0
+vcrpy==7.0.0
+types-requests==2.31.0
+lz4==4.3


### PR DESCRIPTION
## Summary
- add new `requirements-dev.txt` for test packages
- document how to install dev requirements before running tests

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*