### PR TITLE
Add price check to stale order cancellation

### DIFF
--- a/README.md
+++ b/README.md
@@ -163,9 +163,10 @@ immediately after a best bid/offer update instead of waiting for the normal
 
 ## Order expiration
 
-Each order is tagged with a timestamp when placed.  If an order remains open
-longer than `max_order_age` seconds (default: `60`), it will be cancelled on
-the next iteration of the main loop.
+Each order is tagged with a timestamp when placed. If an order remains open
+longer than `max_order_age` seconds (default: `60`) **and** the mid price has
+moved at least `$500` away from the order's price, it will be cancelled on the
+next iteration of the main loop.
 
 
 ## Running tests

--- a/main.py
+++ b/main.py
@@ -415,10 +415,19 @@ class SpotLiquidityBot:
 
     def cancel_expired_orders(self) -> None:
         now = time.time()
+        mid = self._mid_price()
         for oid, info in list(self.open_orders.items()):
             ts = info.get("timestamp")
-            if ts is not None and now - ts > self.max_order_age:
-                self._log(f"Order oid={oid} older than {self.max_order_age}s; canceling")
+            if ts is None:
+                continue
+            if now - ts <= self.max_order_age:
+                continue
+            if mid is None:
+                continue
+            if abs(mid - info["price"]) >= 500:
+                self._log(
+                    f"Order oid={oid} older than {self.max_order_age}s and price moved {abs(mid - info['price'])}; canceling"
+                )
                 self.cancel_order(oid)
                 self.open_orders.pop(oid, None)
 


### PR DESCRIPTION
## Summary
- cancel stale orders only when price is $500 away
- document the new price threshold behavior in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*