### PR TITLE
Remove obsolete RPC_URL

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,7 +27,6 @@ Optional environment variables:
 
 ```bash
 export BASE_URL=https://api.hyperliquid.xyz      # default value
-export RPC_URL=https://api.hyperliquid.xyz/rpc   # default value
 ```
 
 `BASE_URL` should only contain the root API domain. **Do not** append `/rpc` or
@@ -38,14 +37,12 @@ Example values for mainnet:
 
 ```bash
 export BASE_URL=https://api.hyperliquid.xyz
-export RPC_URL=https://api.hyperliquid.xyz/rpc
 ```
 
 And for testnet:
 
 ```bash
 # export BASE_URL=https://api.hyperliquid-testnet.xyz
-# export RPC_URL=https://api.hyperliquid-testnet.xyz/rpc
 ```
 
 If your environment sets `http_proxy` or `https_proxy`, unset them before

--- a/config.py
+++ b/config.py
@@ -15,4 +15,3 @@ if not WALLET_ADDRESS:
     raise EnvironmentError("WALLET_ADDRESS environment variable not set")
 
 BASE_URL = os.environ.get("BASE_URL", "https://api.hyperliquid.xyz")
-RPC_URL = os.environ.get("RPC_URL", "https://api.hyperliquid.xyz/rpc")


### PR DESCRIPTION
## Summary
- drop unused `RPC_URL` configuration variable
- clean up README setup section

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*