### PR TITLE
Add cancel_orders helper

### DIFF
--- a/README.md
+++ b/README.md
@@ -180,3 +180,18 @@ Then execute the test suite:
 ```bash
 pytest
 ```
+
+## Cancel all outstanding UBTC/USDC orders
+
+`cancel_orders.py` removes any open orders resting on the UBTC/USDC spot market. It
+only touches this specific market and leaves all others intact.
+
+Run it like any other helper script:
+
+```bash
+python cancel_orders.py
+```
+
+`WALLET_PRIVATE_KEY`, `WALLET_ADDRESS` and, optionally, `BASE_URL` must be set in
+your environment as described above.
+

--- a/cancel_orders.py
+++ b/cancel_orders.py
@@ -1,0 +1,36 @@
+import os
+import sys
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), "hyperliquid-python-sdk"))
+
+from eth_account import Account
+from hyperliquid.info import Info
+from hyperliquid.exchange import Exchange
+from config import WALLET_PRIVATE_KEY, WALLET_ADDRESS, BASE_URL
+
+
+def main() -> None:
+    """Cancel all outstanding UBTC/USDC orders."""
+
+    account = Account.from_key(WALLET_PRIVATE_KEY)
+    info = Info(BASE_URL, skip_ws=True)
+    exchange = Exchange(account, BASE_URL, account_address=WALLET_ADDRESS)
+
+    coin = info.name_to_coin.get("UBTC/USDC", "UBTC/USDC")
+
+    open_orders = info.open_orders(WALLET_ADDRESS)
+    cancels = [
+        {"coin": order["coin"], "oid": order["oid"]}
+        for order in open_orders
+        if order.get("coin") == coin
+    ]
+
+    if cancels:
+        exchange.bulk_cancel(cancels)
+
+    print(f"Canceled {len(cancels)} UBTC/USDC order(s).")
+
+
+if __name__ == "__main__":
+    main()
+


### PR DESCRIPTION
## Summary
- implement `cancel_orders.py` to bulk cancel UBTC/USDC orders
- document the helper in README

## Testing
- `pytest` *(fails: ModuleNotFoundError for requests and eth_account)*