### PR TITLE
Clarify pytest prerequisites

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,18 +168,19 @@ next iteration of the main loop.
 
 ## Running tests
 
-Install the Python dependencies using `requirements.txt` and the additional
-packages required for tests listed in `requirements-dev.txt`:
+Running `pytest` requires both the regular and development dependencies. Install them first:
 
 ```bash
 pip install -r requirements.txt -r requirements-dev.txt
 ```
 
-Then execute the test suite:
+Afterwards run the suite with:
 
 ```bash
 pytest
 ```
+
+For convenience you can also use the `run-tests.sh` script which installs the requirements and launches `pytest` for you.
 
 ## Cancel all outstanding UBTC/USDC orders
 

--- a/run-tests.sh
+++ b/run-tests.sh
@@ -1,0 +1,5 @@
+#!/bin/bash
+# Install dependencies and run the test suite
+set -e
+pip install -r requirements.txt -r requirements-dev.txt
+pytest "$@"


### PR DESCRIPTION
## Summary
- document that `pytest` requires both requirements files
- add a helper `run-tests.sh` script

## Testing
- `pytest -q` *(fails: No module named 'requests')*