### PR TITLE
Increase order size to $200

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,10 +109,10 @@ bot.
 The bot sizes orders by USD value using the `usd_order_size` parameter.
 For each quote the base asset amount is computed from the current price
 so that the order is worth approximately this many dollars.  The default
-is `20`, meaning each order is for about twenty USDC.
+is `200`, meaning each order is for about two hundred USDC.
 
 ```python
-bot = SpotLiquidityBot(usd_order_size=20.0,
+bot = SpotLiquidityBot(usd_order_size=200.0,
                        spread=0.0004,
                        max_order_age=60)
 ```

--- a/main.py
+++ b/main.py
@@ -17,14 +17,14 @@ from config import WALLET_ADDRESS, WALLET_PRIVATE_KEY, BASE_URL
 
 class SpotLiquidityBot:
     """
-    Simple market-making bot for UBTC/USDC, placing exactly ~20 USD buy/sell orders
+    Simple market-making bot for UBTC/USDC, placing exactly ~200 USD buy/sell orders
     at a chosen spread. With Inventory mgmt, dynamic spreads, and age-based expiry.
     """
 
     def __init__(
         self,
         market: str = "UBTC/USDC",
-        usd_order_size: float = 20.0,    # ~20 USD
+        usd_order_size: float = 200.0,    # ~200 USD
         spread: float = 0.0004,         # e.g. 0.04%
         check_interval: int = 5,
         reprice_threshold: float = 0.005,
@@ -521,7 +521,7 @@ class SpotLiquidityBot:
 if __name__ == "__main__":
     bot = SpotLiquidityBot(
         market="UBTC/USDC",
-        usd_order_size=20.0,
+        usd_order_size=200.0,
         spread=0.0004,
         price_tick=1.0,
         debug=True,


### PR DESCRIPTION
## Summary
- bump default order size to $200
- update README example

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*