### PR TITLE
Increase order expiration time

### DIFF
--- a/README.md
+++ b/README.md
@@ -114,7 +114,7 @@ is `20`, meaning each order is for about twenty USDC.
 ```python
 bot = SpotLiquidityBot(usd_order_size=20.0,
                        spread=0.0004,
-                       max_order_age=60)
+                       max_order_age=90)
 ```
 
 `spread=0.0004` means orders are quoted 0.04% away from the mid price
@@ -155,7 +155,7 @@ immediately after a best bid/offer update instead of waiting for the normal
 ## Order expiration
 
 Each order is tagged with a timestamp when placed. If an order remains open
-longer than `max_order_age` seconds (default: `60`) **and** the mid price has
+longer than `max_order_age` seconds (default: `90`) **and** the mid price has
 moved at least `$500` away from the order's price, it will be cancelled on the
 next iteration of the main loop.
 

--- a/main.py
+++ b/main.py
@@ -31,7 +31,7 @@ class SpotLiquidityBot:
         dynamic_reprice_on_bbo: bool = False,
         debug: bool = True,
         price_tick: float = 1.0,
-        max_order_age: int = 60,
+        max_order_age: int = 90,
         max_btc_position: float = 0.1,
         crash_threshold: float = 0.05,
         crash_window: int = 60,
@@ -525,7 +525,7 @@ if __name__ == "__main__":
         spread=0.0004,
         price_tick=1.0,
         debug=True,
-        max_order_age=60,
+        max_order_age=90,
         max_btc_position=0.1,
     )
     bot.run()


### PR DESCRIPTION
## Summary
- extend default `max_order_age` from 60s to 90s
- document new default in README

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*