### PR TITLE
Fix order refill after fills

### DIFF
--- a/main.py
+++ b/main.py
@@ -272,8 +272,8 @@ class SpotLiquidityBot:
     # ----------------------
     def check_fills(self) -> None:
         chain_orders = self._fetch_open_orders()
-        if not chain_orders:
-            self._log("check_fills => no open orders from exchange or error. skip.")
+        if chain_orders is None:
+            self._log("check_fills => error fetching open orders. skip.")
             self._record_fills()
             return
 


### PR DESCRIPTION
## Summary
- fix early return in `check_fills`

## Testing
- `pytest -q` *(fails: ModuleNotFoundError: No module named 'requests')*